### PR TITLE
feat(crawl): クロール結果のSitemapEntry化・sitemap.json出力・URL正規化対応

### DIFF
--- a/packages/@neutr/crawl/output/sitemap.ts
+++ b/packages/@neutr/crawl/output/sitemap.ts
@@ -1,0 +1,20 @@
+export type SitemapEntry = {
+    url: string;
+    status: number;
+    title?: string;
+    depth: number;
+    parent?: string;
+    redirectedTo?: string;
+};
+
+// @ts-expect-error Node.js型対応
+import { promises as fs } from 'fs';
+// @ts-expect-error Node.js型対応
+import * as path from 'path';
+
+export async function writeSitemapJson(entries: SitemapEntry[], outputDir = 'output') {
+    const outPath = path.join(outputDir, 'sitemap.json');
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(outPath, JSON.stringify(entries, null, 2), 'utf-8');
+    return outPath;
+}


### PR DESCRIPTION
## 概要\n- クロール結果をSitemapEntry型でまとめ、output/sitemap.jsonに出力する処理を実装\n- URLの正規化（末尾スラッシュ除去）を追加\n- ルート呼び出し時のみsitemap.jsonを出力\n\n## 次のアクション\n- CLI連携（commanderでneutr crawlコマンド実装）\n\nLet’s GYARRRRRRRUUUUUUUUUUUUUU DEV FINAL FORM！！！