### PR TITLE
feat(cli): neutr crawlコマンド初期実装（commander連携）

### DIFF
--- a/packages/@neutr/cli/index.ts
+++ b/packages/@neutr/cli/index.ts
@@ -17,7 +17,7 @@ program
     .option('--depth <depth>', 'クロール深さ', '1')
     .action(async (opts) => {
         const url = opts.url;
-        const depth = parseInt(opts.depth, 10) || 1;
+        const depth = isNaN(parseInt(opts.depth, 10)) ? 1 : parseInt(opts.depth, 10);
         console.log(`🕸️ クロール開始: ${url} (depth=${depth})`);
         await crawl({ url, depth });
         console.log('✅ sitemap.json 出力完了');

--- a/packages/@neutr/cli/index.ts
+++ b/packages/@neutr/cli/index.ts
@@ -1,1 +1,26 @@
-// cli entry point
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { crawl } from '@neutr/crawl';
+
+const program = new Command();
+
+program
+    .name('neutr')
+    .description('NeutrPlatform CLI')
+    .version('0.1.0');
+
+program
+    .command('crawl')
+    .description('指定URLをクロールし、sitemap.jsonを出力')
+    .requiredOption('--url <url>', 'クロール開始URL')
+    .option('--depth <depth>', 'クロール深さ', '1')
+    .action(async (opts) => {
+        const url = opts.url;
+        const depth = parseInt(opts.depth, 10) || 1;
+        console.log(`🕸️ クロール開始: ${url} (depth=${depth})`);
+        await crawl({ url, depth });
+        console.log('✅ sitemap.json 出力完了');
+    });
+
+program.parse(process.argv);


### PR DESCRIPTION
## 概要\n- @neutr/cliにcommanderを使ったneutr crawlコマンドを初期実装\n- --url, --depthオプションでクロール実行＆output/sitemap.json出力\n- @neutr/crawlのcrawl関数を呼び出し\n\n## 次のアクション\n- CLIのエラー処理・開発者体験強化\n- .cursor/commands.mdcでコマンド定義管理\n\nLet’s GYARRRRRRRRRRRUUUUU CLI Revolution！！